### PR TITLE
Debug match full words and invert match

### DIFF
--- a/src/nfa.c
+++ b/src/nfa.c
@@ -434,10 +434,10 @@ match_status_t search_buffer(char *buf, size_t bufsize, nfa_t *nfa,
         //fprintf(stderr, "Forked thread on q%d->q%d: %c at position %d\n", ((nfa_arg_t *)arg)->state->id, future_child_state->id, ((nfa_arg_t *)arg)->buf[((nfa_arg_t *)arg)->pos], ((nfa_arg_t *)arg)->pos);
         if (match_full_words) { /* advance until buf[pos] is whitespace */
 SKIP_TO_NEXT_WORD:
-            retval = NULL;  /* use retval as a bool to avoid declaring a new variable */
             while (pos < bufsize) {
                 switch (buf[pos]) {
                 case '\0':
+                    goto END_OF_BUF;
                 case '\t':
                 case ' ':
                     goto FOUND_WHITESPACE;
@@ -448,6 +448,7 @@ SKIP_TO_NEXT_WORD:
 FOUND_WHITESPACE:
         }
     }
+END_OF_BUF:
     while (head != NULL) {
         pthread_join(head->thread, &retval);
         if (match_full_words) {

--- a/src/nfa.c
+++ b/src/nfa.c
@@ -396,6 +396,8 @@ match_status_t search_buffer(char *buf, size_t bufsize, nfa_t *nfa,
         }
         if (cur_transition == NULL) {
             /* no viable transitions, move on */
+            if (match_full_words)
+                goto SKIP_TO_NEXT_WORD;
             continue;
         }
         /* "fork" a child to search from this index */
@@ -431,6 +433,7 @@ match_status_t search_buffer(char *buf, size_t bufsize, nfa_t *nfa,
         pthread_create(&tmp->thread, NULL, &run_nfa, &tmp->arg);
         //fprintf(stderr, "Forked thread on q%d->q%d: %c at position %d\n", ((nfa_arg_t *)arg)->state->id, future_child_state->id, ((nfa_arg_t *)arg)->buf[((nfa_arg_t *)arg)->pos], ((nfa_arg_t *)arg)->pos);
         if (match_full_words) { /* advance until buf[pos] is whitespace */
+SKIP_TO_NEXT_WORD:
             retval = NULL;  /* use retval as a bool to avoid declaring a new variable */
             while (pos < bufsize) {
                 switch (buf[pos]) {

--- a/src/nfa.c
+++ b/src/nfa.c
@@ -374,13 +374,17 @@ match_status_t search_buffer(char *buf, size_t bufsize, nfa_t *nfa,
     void *retval;
     match_status_t match_status = MATCH_NONE;
     transition_t *cur_transition;
+    char c;
     for (pos = 0; pos < bufsize && buf[pos] != '\0'; pos++) {
+        c = buf[pos];
+        if (case_insensitive && c >= 0x41 && c <= 0x5A)
+            c |= 0x20;
         cur_transition = nfa->q0->transitions;
         while (cur_transition != NULL) {
             if (cur_transition->flags == FLAG_WILDCARD ||
                     (cur_transition->flags == FLAG_INVERT ?
-                     cur_transition->symbol != buf[pos] :
-                     cur_transition->symbol == buf[pos]))
+                     cur_transition->symbol != c :
+                     cur_transition->symbol == c))
                 break;
             cur_transition = cur_transition->next;
         }

--- a/src/nfa.h
+++ b/src/nfa.h
@@ -71,7 +71,7 @@ void print_nfa(nfa_t *nfa, FILE *outfile);
 
 void free_nfa();
 
-match_status_t search_buffer(char *buf, size_t bufsize, nfa_t *nfa, match_list_t *match_list, int case_insensitive, int match_full_words, int match_full_lines);
+match_status_t search_buffer(char *buf, size_t bufsize, nfa_t *nfa, match_list_t *match_list, int case_insensitive, int match_full_words, int match_full_lines, int invert_match);
 
 
 #endif  /* #ifndef NFA_H */

--- a/src/perg.c
+++ b/src/perg.c
@@ -242,7 +242,8 @@ match_status_t search_file(char *filename, FILE *infile, nfa_t *nfa, arg_flag_t 
                 goto RETURN_STATUS;
             break;
         case MATCH_PROGRESS:
-            /* Possibly full matches in list, so check full list to see if a full match is found */
+            /* Possibly full matches in list, so check full list to see if a
+             * full match is found */
             earliest_partial_start = match_list.head->start;
             while (match_list.head != NULL) {
                 if (match_list.head->end != 0)  /* only MATCH_FOUND has end != 0 */

--- a/src/perg.c
+++ b/src/perg.c
@@ -168,11 +168,19 @@ match_status_t search_file(char *filename, FILE *infile, nfa_t *nfa, arg_flag_t 
         status = search_buffer(buf, bufsize, nfa, &match_list,
                                flags & ARG_FLAG_I,
                                flags & ARG_FLAG_W,
-                               flags & ARG_FLAG_X );
+                               flags & ARG_FLAG_X,
+                               flags & ARG_FLAG_V);
         switch (status) {
         case MATCH_FOUND:
             confirmed_match = MATCH_FOUND;
             i = 0;
+            if (flags & ARG_FLAG_V) {
+                while (match_list.head != NULL) {
+                    tmp = match_list.head;
+                    match_list.head = tmp->next;
+                    free(tmp);
+                }
+            }
             while (match_list.head != NULL) {
                 if (match_list.head->end == bufsize) {
                     /* reached the end of complete matches, so stop printing
@@ -226,6 +234,13 @@ match_status_t search_file(char *filename, FILE *infile, nfa_t *nfa, arg_flag_t 
                 goto RETURN_STATUS;
             break;
         case MATCH_NONE:
+            while (match_list.head != NULL) {
+                /* if invert_match, will have matches in the list, else does nothing */
+                tmp = match_list.head;
+                match_list.head = tmp->next;
+                free(tmp);
+            }
+            match_list.tail = NULL;
             if ((bytes_read = fill_buffer(infile, &buf, &bufsize, &binary, flags & ARG_FLAG_A)) == ERR_EOF)
                 goto RETURN_STATUS;
             /* assert((match_list.head | match_list.tail) == NULL); */
@@ -236,9 +251,17 @@ match_status_t search_file(char *filename, FILE *infile, nfa_t *nfa, arg_flag_t 
         status = search_buffer(buf, bufsize, nfa, &match_list,
                                flags & ARG_FLAG_I,
                                flags & ARG_FLAG_W,
-                               flags & ARG_FLAG_X);
+                               flags & ARG_FLAG_X,
+                               flags & ARG_FLAG_V);
         switch (status) {
         case MATCH_NONE:
+            while (match_list.head != NULL) {
+                /* if invert_match, will have matches in the list, else does nothing */
+                tmp = match_list.head;
+                match_list.head = tmp->next;
+                free(tmp);
+            }
+            match_list.tail = NULL;
             if (bytes_read = fill_buffer(infile, &buf, &bufsize, &binary, flags & ARG_FLAG_A) == ERR_EOF)
                 goto RETURN_STATUS;
             break;

--- a/src/perg.c
+++ b/src/perg.c
@@ -6,8 +6,9 @@
 #include "nfa.h"
 
 
-#define ERR_EOF     0
+#define DEFAULT_BUFSIZE 512
 
+#define ERR_EOF     0
 
 #define COLOR_RESET ("\e[0;39;49m")
 
@@ -145,7 +146,7 @@ void print_from_buffer(char *buf, size_t start, size_t end, color_t color, bold_
 
 match_status_t search_file(char *filename, FILE *infile, nfa_t *nfa, arg_flag_t flags) {
     char *buf, *fake_buf;
-    size_t bytes_read, bufsize = 4096, bytes_preserved, bytes_remaining, earliest_partial_start, i;
+    size_t bytes_read, bufsize = DEFAULT_BUFSIZE, bytes_preserved, bytes_remaining, earliest_partial_start, i;
     int binary = 0;
     match_list_t match_list;
     match_list_ele_t *tmp;


### PR DESCRIPTION
I broke up the previous head commit into various smaller commits in the branch, and additionally fixed other bugs and omissions. The main problem with the original head was using bytes_read in search_buffer() instead of using bufsize. The branch version is strictly better than the main head, and should replace it.